### PR TITLE
Created obs_record.py

### DIFF
--- a/utils/obs_record.py
+++ b/utils/obs_record.py
@@ -1,0 +1,73 @@
+import os
+import sys
+import time
+from dotenv import load_dotenv
+from selenium import webdriver
+from selenium.webdriver.chrome.options import Options
+from obswebsocket import obsws, requests
+
+
+load_dotenv()
+
+# OBS Studio Websocket Settings
+obs_settings = {
+    "obs_host": os.environ.get("OBS_HOST"),
+    "obs_port": int(os.environ.get("OBS_PORT")),
+    "obs_password": os.environ.get("OBS_PASSWORD"),
+    "record_path": os.environ.get("RECORD_PATH"),
+}
+
+# This is NOT working yet
+# Start recording based on a javacript event.
+def start_recording_if_playing():
+    is_playing = driver.execute_script("return isPlaying;")
+    if is_playing:
+        start_recording = requests.StartRecord()
+        ws.call(start_recording)
+        print("Recording started")
+
+# Set up Chrome options to start in full-screen mode
+chrome_options = Options()
+chrome_options.add_argument('--kiosk')
+
+# Create a WebDriver instance (make sure you have the ChromeDriver executable in your PATH)
+driver = webdriver.Chrome(options=chrome_options)
+
+url_path = sys.argv[1] if len(sys.argv) > 1 else "https://replicantlife.com/"
+driver.get(url_path) # Open a website
+
+# Allow some time for the page to load
+time.sleep(3)
+
+# Connect to OBS Studio via WebSocket
+ws = obsws(obs_settings["obs_host"], obs_settings["obs_port"], obs_settings["obs_password"])
+ws.connect()
+
+# Set the recording path in OBS Studio
+recording_path = obs_settings["record_path"]
+set_recording_path = requests.SetRecordDirectory(recording_path=recording_path)
+ws.call(set_recording_path)
+
+# Check current recording status
+current_recording_status = ws.call(requests.GetRecordStatus())
+print("Current recording status:", current_recording_status)
+
+# Start recording in OBS Studio
+start_recording = requests.StartRecord()
+ws.call(start_recording)
+
+# The function is NOT working yet.
+# start_recording_if_playing()
+
+# Continue recording for 20s (adjust as needed)
+time.sleep(20)
+
+# Stop recording in OBS Studio
+stop_recording = requests.StopRecord()
+ws.call(stop_recording)
+
+# Close the browser when done
+driver.quit()
+
+# Disconnect from OBS Studio
+ws.disconnect()


### PR DESCRIPTION
Automatically records the simulation replay on the web browser (currently for 20 seconds) upon execution of the script.

1. Download and install the following:
`pip install obs-websocket-py`
`pip install selenium`

OBS studio: https://obsproject.com/download

2. Add this to your PATH:
ChromeDriver: https://googlechromelabs.github.io/chrome-for-testing/#stable
(i used the stable channel)

3. Include these in the .env file:
(get the host, port, password on your obs studio, tools > websocket server settings > show connect info)
(also make sure to check "enable websocket server")

OBS_HOST=localhost
OBS_PORT=4444
OBS_PASSWORD=password
RECORD_PATH=your desired path

4. Execute the python script (the url of the replay is taken as an argument)
`python utils/obs_record.py insert-url-here`

NOTE:
Start recording based on a javascript event is not working yet.
I tried to use the isPlaying variable on the RenderLevel.tsx but it returns an error.

From chatgpt: 
> The error message indicates that the isPlaying variable is not defined in the JavaScript context of the page. This suggests that the script is unable to access the isPlaying variable because it's not present on the page or it's defined in a scope that's not accessible to the script.
