### PR TITLE
click play to start simulation

### DIFF
--- a/web/src/components/RenderLevel.tsx
+++ b/web/src/components/RenderLevel.tsx
@@ -30,7 +30,7 @@ async function getData(sim_id: string, fromIndex: number) {
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const RenderLevel: React.FC<{ simId: string, map?: string | null, img?: string | null, hidePanel: boolean }> = ({ simId, map, img, hidePanel }) => {
 
-    const [isPlaying, setIsPlaying] = useState(true);
+    const [isPlaying, setIsPlaying] = useState(false);
     const [followAgent, setFollowAgent] = useState<Agent | undefined>(undefined);
     const [levelState, setLevelState] = useState<LevelState>({ stepId: 0, substepId: 0, agents: [] });
     const [fetchIndex, setFetchIndex] = useState(0);


### PR DESCRIPTION
browsers need user interaction to enable playing audio.
so instead of starting the simulation automatically after loading the page, we click play button first.